### PR TITLE
Fix test email and add reminder smtp settings

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -31,4 +31,6 @@ export interface SmtpSettings {
   port: number;
   user: string;
   pass: string;
+  fromEmail: string;
+  toEmail: string;
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -59,7 +59,9 @@ const initialState: AppState = {
     host: '',
     port: 587,
     user: '',
-    pass: ''
+    pass: '',
+    fromEmail: '',
+    toEmail: ''
   },
   isProjectDialogOpen: false,
   editingProject: null,
@@ -110,7 +112,9 @@ export const useAppStore = create<AppState & AppActions>()(
               host: result.data.host || '',
               port: result.data.port || 587,
               user: result.data.user || '',
-              pass: '' // Don't load password for security
+              pass: '', // Don't load password for security
+              fromEmail: result.data.fromEmail || '',
+              toEmail: result.data.toEmail || ''
             }
           });
         }


### PR DESCRIPTION
Add configurable 'From' and 'To' email addresses to SMTP settings and fix test email sender rejection.

The previous test email used a hardcoded sender (`test@example.com`), which caused rejection by SMTP servers requiring the sender to be owned by the authenticated user. This PR ensures the configured `fromEmail` is used for all outgoing emails and provides dedicated fields for reminder recipients.

---
<a href="https://cursor.com/background-agent?bcId=bc-42b4ce77-7382-4359-8f66-26fabce44191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42b4ce77-7382-4359-8f66-26fabce44191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

