### PR TITLE
Fix missing nginx start script in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,111 @@
+# Node modules
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build outputs
+dist
+build
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE files
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git
+.gitignore
+
+# Documentation
+*.md
+docs/
+
+# Test files
+test/
+*.test.js
+*.test.ts
+*.spec.js
+*.spec.ts
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# next.js build output
+.next
+
+# nuxt.js build output
+.nuxt
+
+# vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# TernJS port file
+.tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# Temporary folders
+tmp/
+temp/
+
+# Keep these files for Docker build
+!start-nginx.sh
+!nginx.conf
+!Dockerfile.frontend
+!package.json
+!package-lock.json

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -31,8 +31,9 @@ COPY --from=builder /app/dist .
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Copy startup script
+# Copy startup script and make it executable
 COPY start-nginx.sh /start-nginx.sh
+RUN chmod +x /start-nginx.sh
 
 # Create a proper nginx.conf that includes our configuration
 RUN echo 'events { worker_connections 1024; }' > /etc/nginx/nginx.conf && \
@@ -40,11 +41,12 @@ RUN echo 'events { worker_connections 1024; }' > /etc/nginx/nginx.conf && \
     echo '  include /etc/nginx/conf.d/*.conf;' >> /etc/nginx/nginx.conf && \
     echo '}' >> /etc/nginx/nginx.conf
 
-# Make startup script executable
-RUN chmod +x /start-nginx.sh
+# Verify the startup script exists and is executable
+RUN ls -la /start-nginx.sh && test -x /start-nginx.sh && echo "Startup script verified successfully"
 
 # Expose port 80
 EXPOSE 80
 
 # Start nginx with backend check
-CMD ["/start-nginx.sh"]
+# Use exec to ensure proper signal handling
+CMD ["/bin/sh", "-c", "if [ -f /start-nginx.sh ] && [ -x /start-nginx.sh ]; then exec /start-nginx.sh; else echo 'ERROR: /start-nginx.sh not found or not executable'; exit 1; fi"]

--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Debug: Check if script is running
+echo "Starting nginx startup script..."
+echo "Script location: $(pwd)"
+echo "Script permissions: $(ls -la /start-nginx.sh)"
+
 # Wait for backend to be ready with timeout
 echo "Waiting for backend to be ready..."
 MAX_ATTEMPTS=60

--- a/test-frontend-build.sh
+++ b/test-frontend-build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+echo "🔧 Testing Frontend Docker Build Fix"
+echo "===================================="
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker not available - please install Docker first"
+    exit 1
+fi
+
+echo "🔨 Building frontend Docker image..."
+if docker build -t todo-frontend-test -f Dockerfile.frontend .; then
+    echo "✅ Frontend build successful"
+else
+    echo "❌ Frontend build failed"
+    exit 1
+fi
+
+echo "🔍 Testing if startup script exists in the image..."
+if docker run --rm todo-frontend-test ls -la /start-nginx.sh; then
+    echo "✅ Startup script found in image"
+else
+    echo "❌ Startup script not found in image"
+    exit 1
+fi
+
+echo "🔍 Testing if startup script is executable..."
+if docker run --rm todo-frontend-test test -x /start-nginx.sh; then
+    echo "✅ Startup script is executable"
+else
+    echo "❌ Startup script is not executable"
+    exit 1
+fi
+
+echo "🚀 Testing container startup (will timeout after 30 seconds)..."
+timeout 30s docker run --rm --name todo-frontend-test todo-frontend-test || echo "Container startup test completed (timeout expected)"
+
+echo "🧹 Cleaning up test image..."
+docker rmi todo-frontend-test
+
+echo "🎉 Frontend Docker build fix verification completed!"
+echo ""
+echo "To test with docker-compose:"
+echo "  docker-compose up frontend"


### PR DESCRIPTION
Fix frontend Docker build to prevent restarts caused by a missing or unexecutable `start-nginx.sh` script.

---
<a href="https://cursor.com/background-agent?bcId=bc-763f4b61-7feb-4b56-8754-7dc21fa7741b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-763f4b61-7feb-4b56-8754-7dc21fa7741b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

